### PR TITLE
ci: harden workflow GITHUB_TOKEN with least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["main"]
 
+# Restrict GITHUB_TOKEN to read-only at workflow level. Jobs that need
+# write access (publish, deploy) declare their own `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint + Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,18 +9,23 @@ on:
 env:
   PYTHON_VERSION: '3.11'
 
+# Restrict GITHUB_TOKEN to read-only at workflow level. Jobs that need
+# write access (publish, deploy) declare their own `permissions:` block.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -35,20 +40,20 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
-      
+
       - name: Build distribution
         run: python -m build
-      
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -67,7 +72,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
## Summary
- Adds workflow-level `permissions: contents: read` to every GitHub Actions workflow in this repo, restricting the `GITHUB_TOKEN` to read-only by default (CodeQL `actions/missing-workflow-permissions` rule).
- Jobs that need write access (publish, deploy) already declare elevated `permissions:` — no functional change.
- Closes the open code-scanning alerts in this repo.

## Test plan
- [ ] CI pipeline runs successfully against the PR head with workflow-level read-only token.
- [ ] CodeQL re-analysis shows the `actions/missing-workflow-permissions` alerts auto-closed once merged to `main`.

Hardening sweep 2026-05-04 — Platinum Audit.